### PR TITLE
bugfix: run trombik.nginx after zabbix_frontend

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,4 @@ zabbix_frontend_package: "{{ __zabbix_frontend_package }}"
 zabbix_frontend_extra_packages: []
 zabbix_frontend_conf_dir: "{{ __zabbix_frontend_conf_dir }}"
 zabbix_frontend_conf_file: "{{ zabbix_frontend_conf_dir }}/zabbix.conf.php"
+zabbix_frontend_web_root: "{{ __zabbix_frontend_web_root }}"

--- a/tests/serverspec/default.yml
+++ b/tests/serverspec/default.yml
@@ -4,10 +4,10 @@
     - role: trombik.freebsd_pkg_repo
       when: ansible_os_family == 'FreeBSD'
     - role: trombik.php_fpm
-    - role: trombik.nginx
     - role: trombik.apt_repo
       when: ansible_os_family == 'Debian'
     - ansible-role-zabbix_frontend
+    - role: trombik.nginx
   vars:
     apt_repo_enable_apt_transport_https: yes
     # https://repo.zabbix.com/zabbix/5.4/ubuntu/pool/main/z/zabbix-release/zabbix-release_5.4-1+ubuntu20.04_all.deb
@@ -81,11 +81,6 @@
         priority: 99
 
     # _______________________________________________nginx
-    os_www_root_dir:
-      FreeBSD: /usr/local/www/zabbix54
-      Debian: /usr/share/zabbix
-      OpenBSD: /var/www/zabbix
-    www_root_dir: "{{ os_www_root_dir[ansible_os_family] }}"
     nginx_flags: -q
     nginx_config: |
       {% if ansible_os_family == 'Debian' or ansible_os_family == 'RedHat' %}
@@ -106,7 +101,7 @@
         server {
           listen 80;
           server_name localhost;
-          root {{ www_root_dir }};
+          root {{ zabbix_frontend_web_root }};
           location / {
             index index.html index.php;
           }

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -3,3 +3,4 @@ __zabbix_frontend_user: www-data
 __zabbix_frontend_group: www-data
 __zabbix_frontend_conf_dir: /usr/share/zabbix/conf
 __zabbix_frontend_package: zabbix-frontend-php
+__zabbix_frontend_web_root: /usr/share/zabbix

--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -3,3 +3,4 @@ __zabbix_frontend_user: www
 __zabbix_frontend_group: www
 __zabbix_frontend_conf_dir: /usr/local/www/zabbix54/conf
 __zabbix_frontend_package: zabbix54-frontend
+__zabbix_frontend_web_root: /usr/local/www/zabbix54

--- a/vars/OpenBSD.yml
+++ b/vars/OpenBSD.yml
@@ -3,3 +3,4 @@ __zabbix_frontend_user: www
 __zabbix_frontend_group: www
 __zabbix_frontend_conf_dir: /var/www/zabbix/conf
 __zabbix_frontend_package: zabbix-web
+__zabbix_frontend_web_root: /var/www/zabbix


### PR DESCRIPTION
eliminating www_root_dir